### PR TITLE
Newer servant

### DIFF
--- a/servant-matrix-param.cabal
+++ b/servant-matrix-param.cabal
@@ -36,7 +36,7 @@ library
       Servant.MatrixParam
   if flag(with-servant-aeson-specs)
     build-depends:
-        servant-aeson-specs == 0.2.* || == 0.3.* || == 0.4.*
+        servant-aeson-specs > 0.2 && < 0.6
     exposed-modules:
         Servant.MatrixParam.AesonSpecs
   if flag(with-servant-server)

--- a/servant-matrix-param.cabal
+++ b/servant-matrix-param.cabal
@@ -31,7 +31,7 @@ library
       src
   build-depends:
       base < 5
-    , servant == 0.5
+    , servant >= 0.5 && < 0.10
   exposed-modules:
       Servant.MatrixParam
   if flag(with-servant-aeson-specs)
@@ -41,13 +41,15 @@ library
         Servant.MatrixParam.AesonSpecs
   if flag(with-servant-server)
     build-depends:
-      servant-server == 0.5,
+      servant-server >= 0.5 && < 0.10,
+      http-api-data >= 0.2 && < 0.4,
       containers,
       string-conversions,
       text
     exposed-modules:
       Servant.MatrixParam.Server
       Servant.MatrixParam.Server.Internal
+      Servant.MatrixParam.Server.Internal.ArgList
 
 test-suite spec
   default-language: Haskell2010
@@ -59,7 +61,7 @@ test-suite spec
   build-depends:
       base < 5
     , hspec
-    , servant == 0.5
+    , servant >= 0.7 && < 0.10
     , servant-aeson-specs
     , servant-matrix-param
     , servant-server
@@ -85,5 +87,5 @@ test-suite doctest
       test
   build-depends:
       base < 5
-    , servant == 0.5
+    , servant >= 0.7 && < 0.10
     , doctest

--- a/servant-matrix-param.cabal
+++ b/servant-matrix-param.cabal
@@ -31,7 +31,7 @@ library
       src
   build-depends:
       base < 5
-    , servant >= 0.5 && < 0.10
+    , servant >= 0.7 && < 0.10
   exposed-modules:
       Servant.MatrixParam
   if flag(with-servant-aeson-specs)
@@ -41,7 +41,7 @@ library
         Servant.MatrixParam.AesonSpecs
   if flag(with-servant-server)
     build-depends:
-      servant-server >= 0.5 && < 0.10,
+      servant-server >= 0.7 && < 0.10,
       http-api-data >= 0.2 && < 0.4,
       containers,
       string-conversions,

--- a/src/Servant/MatrixParam/AesonSpecs.hs
+++ b/src/Servant/MatrixParam/AesonSpecs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
@@ -13,4 +14,8 @@ import           Servant.Aeson.Internal
 import           Servant.MatrixParam
 
 instance HasGenericSpecs api => HasGenericSpecs (WithMatrixParams path params :> api) where
+#if MIN_VERSION_servant_aeson_specs(0,5,0)
+  collectRoundtripSpecs settings Proxy = collectRoundtripSpecs settings (Proxy :: Proxy api)
+#else
   collectRoundtripSpecs Proxy = collectRoundtripSpecs (Proxy :: Proxy api)
+#endif

--- a/src/Servant/MatrixParam/Server/Internal.hs
+++ b/src/Servant/MatrixParam/Server/Internal.hs
@@ -12,6 +12,7 @@ import           Data.Map.Strict
 import           Data.Maybe
 import           Data.Text
 
+
 data MatrixSegment
   = MatrixSegment {
     segmentPath :: Text,

--- a/src/Servant/MatrixParam/Server/Internal.hs
+++ b/src/Servant/MatrixParam/Server/Internal.hs
@@ -38,7 +38,7 @@ parsePair pair = case splitOn "=" pair of
   [flag] -> Just (flag, Nothing)
   _ -> Nothing
 
-collectPairs :: forall a b . Show b => Ord a => [(a, Maybe b)] -> Map a b
+collectPairs :: forall a b . Ord a => [(a, Maybe b)] -> Map a b
 collectPairs =
   Data.List.foldl'
     (\ acc (k, mv) -> maybe acc (\ v -> insert k v acc) mv)

--- a/src/Servant/MatrixParam/Server/Internal/ArgList.hs
+++ b/src/Servant/MatrixParam/Server/Internal/ArgList.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+module Servant.MatrixParam.Server.Internal.ArgList where
+
+import qualified Data.Map            as Map
+import           Data.Proxy
+import qualified Data.Text           as T
+import           GHC.TypeLits        (KnownSymbol, symbolVal)
+import           Servant.MatrixParam
+import           Web.HttpApiData     (parseQueryParamMaybe, FromHttpApiData)
+
+-- An HList that stores the arguments to a function
+data ArgList a where
+  NoArgs :: ArgList '[]
+  (:.:)  :: Maybe a -> ArgList as -> ArgList (MatrixParam key a ': as)
+
+type family Unapped (params :: [*]) end where
+  Unapped '[] r = r
+  Unapped (MatrixParam key a ': rest) r = Maybe a -> Unapped rest r
+
+class (Apped (Unapped argList fn) argList ~ fn) => App fn (argList :: [*]) where
+  type Apped fn argList
+  -- Applies a function to an ArgList
+  apply :: fn -> ArgList argList -> Apped fn argList
+
+class ParseArgs argList where
+  -- Gets the arguments from a map
+  parseArgs :: Map.Map T.Text T.Text -> ArgList argList
+
+instance (App r rest
+        , Apped (Unapped rest (Maybe a -> r)) rest ~ (Maybe a -> r)
+        ) => App (Maybe a -> r) (MatrixParam key a ': rest) where
+  type Apped (Maybe a -> r) (MatrixParam key a ': rest) = Apped r rest
+  apply fn (a :.: rest) = apply (fn a) rest
+
+instance (FromHttpApiData a, KnownSymbol key, ParseArgs rest) => ParseArgs (MatrixParam key a ': rest) where
+  parseArgs m = val :.: (parseArgs m :: ArgList rest)
+    where
+      key = T.pack $ symbolVal (Proxy :: Proxy key)
+      val = Map.lookup key m >>= parseQueryParamMaybe
+
+instance App r '[] where
+  type Apped r '[] = r
+  apply r _ = r
+
+instance ParseArgs '[] where
+  parseArgs _ = NoArgs

--- a/stack-servant-0.7.yaml
+++ b/stack-servant-0.7.yaml
@@ -1,11 +1,10 @@
-resolver: nightly-2016-10-04
+resolver: lts-6.10
 packages:
   - '.'
 extra-deps:
-- servant-aeson-specs-0.5.2.0
-- servant-0.9
-- servant-server-0.9
-- http-api-data-0.3.1
+- servant-aeson-specs-0.4.1
+- servant-0.7.1
+- servant-server-0.7.1
 flags:
   servant-matrix-param:
     with-servant-aeson-specs: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,8 @@
 resolver: lts-6.10
 packages:
   - '.'
-  - location:
-      git: https://github.com/plow-technologies/servant-aeson-specs
-      commit: "0.4"
-    extra-dep: true
 extra-deps:
-  - servant-0.5
-  - servant-server-0.5
+- servant-aeson-specs-0.4.1
 flags:
   servant-matrix-param:
     with-servant-aeson-specs: true

--- a/test/Servant/MatrixParam/ServerSpec.hs
+++ b/test/Servant/MatrixParam/ServerSpec.hs
@@ -5,7 +5,6 @@
 module Servant.MatrixParam.ServerSpec where
 
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except
 import           Data.ByteString.Lazy
 import           Data.Map.Strict
 import           Data.Proxy
@@ -28,8 +27,6 @@ type Api =
 
 api :: Proxy Api
 api = Proxy
-
-type Handler = ExceptT ServantErr IO
 
 server :: Server Api
 server = a :<|> b

--- a/travis.sh
+++ b/travis.sh
@@ -8,4 +8,5 @@ stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:with
 stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:-with-servant-aeson-specs --flag servant-matrix-param:with-servant-server
 stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:-with-servant-aeson-specs --flag servant-matrix-param:-with-servant-server
 
-stack test  --ghc-options=-Werror --no-terminal --flag --stack-yaml=stack-servant-0.7.yaml
+stack setup --no-terminal --stack-yaml=stack-servant-0.7.yaml
+stack test  --ghc-options=-Werror --no-terminal --stack-yaml=stack-servant-0.7.yaml

--- a/travis.sh
+++ b/travis.sh
@@ -7,3 +7,5 @@ stack test  --ghc-options=-Werror --no-terminal --flag servant-matrix-param:with
 stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:with-servant-aeson-specs  --flag servant-matrix-param:-with-servant-server
 stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:-with-servant-aeson-specs --flag servant-matrix-param:with-servant-server
 stack build --ghc-options=-Werror --no-terminal --flag servant-matrix-param:-with-servant-aeson-specs --flag servant-matrix-param:-with-servant-server
+
+stack test  --ghc-options=-Werror --no-terminal --flag --stack-yaml=stack-servant-0.7.yaml


### PR DESCRIPTION
  This PR adds support for the latest versions of `servant`, `servant-server`, `servant-aeson-specs`, and `http-api-data`.

